### PR TITLE
Adding e2e tests for supported APIs.

### DIFF
--- a/tests/e2e/client/Makefile
+++ b/tests/e2e/client/Makefile
@@ -7,7 +7,7 @@ all: upload test
 test:
 	virtualenv env
 	env/bin/pip install -r requirements.txt
-	env/bin/python main.py https://${GCLOUD_PROJECT}.appspot.com/
+	env/bin/python main.py http://${GCLOUD_PROJECT}.appspot.com/
 
 .PHONY: upload
 upload:

--- a/tests/e2e/tests/logging_test.py
+++ b/tests/e2e/tests/logging_test.py
@@ -1,13 +1,9 @@
-"""E2E test for logging API.
-
-Currently DOES NOT work.
-"""
+from google.appengine.api.logservice import logservice
 import json
 import logging
 import os
 import pytest
 
-from google.appengine.api.logservice import logservice
 
 
 @pytest.fixture

--- a/tests/e2e/tests/logging_test.py
+++ b/tests/e2e/tests/logging_test.py
@@ -14,13 +14,10 @@ from google.appengine.api.logservice import logservice
 def request_id():
   return os.environ.get('REQUEST_LOG_ID')
 
-def test_log(request_id):
-  logging.info('TESTING')
-
-
-# This test must happen after test_log.
+@pytest.mark.xfail
 def do_not_run_test_logservice_fetch(request_id):
   """This test fails at logservice.fetch"""
+  logging.info('TESTING')
   found_log = False
   for req_log in logservice.fetch(
       request_ids=[request_id],

--- a/tests/e2e/tests/logging_test.py
+++ b/tests/e2e/tests/logging_test.py
@@ -1,0 +1,33 @@
+"""E2E test for logging API.
+
+Currently DOES NOT work.
+"""
+import json
+import logging
+import os
+import pytest
+
+from google.appengine.api.logservice import logservice
+
+
+@pytest.fixture
+def request_id():
+  return os.environ.get('REQUEST_LOG_ID')
+
+def test_log(request_id):
+  logging.info('TESTING')
+
+
+# This test must happen after test_log.
+def do_not_run_test_logservice_fetch(request_id):
+  """This test fails at logservice.fetch"""
+  found_log = False
+  for req_log in logservice.fetch(
+      request_ids=[request_id],
+      include_app_logs=True):
+    for app_log in req_log.app_logs:
+      if app_log.message == 'TESTING':
+        found_log = True
+
+  assert found_log
+

--- a/tests/e2e/tests/memcache_test.py
+++ b/tests/e2e/tests/memcache_test.py
@@ -1,0 +1,39 @@
+"""Tests for the memcache API.
+
+This test module is incomplete but is a starter.
+"""
+
+import pytest
+import time
+
+from google.appengine.api import memcache
+
+
+@pytest.fixture
+def defaults():
+  memcache.flush_all()
+  return {
+      'client': memcache._CLIENT,
+      'mapping': {
+          'key1', 'data1',
+          'key2', 'data2',
+          'key3', 'data3',
+      },
+      'timeout': 2,
+      'timeout_tolerance': 2,
+      'namespace1': 'foo',
+      'namespace2': 'bar',
+      'default_range': 10,
+      'default_incr_start': 1,
+      'default_decr_start': 1000,
+      'default_delta': 10,
+  }
+
+
+def test_memcache(defaults):
+  assert memcache.get('key1') == None
+  memcache.set('key1', 'data1')
+  assert memcache.get('key1') == 'data1'
+  assert memcache.set('key1', 'data1', defaults['timeout'])
+  time.sleep(defaults['timeout'] + defaults['timeout_tolerance'])
+  assert memcache.get('key1') == None

--- a/tests/e2e/tests/memcache_test.py
+++ b/tests/e2e/tests/memcache_test.py
@@ -1,7 +1,4 @@
-"""Tests for the memcache API.
-
-This test module is incomplete but is a starter.
-"""
+"""Tests for the memcache API."""
 
 import pytest
 import time

--- a/tests/e2e/tests/memcache_test.py
+++ b/tests/e2e/tests/memcache_test.py
@@ -1,36 +1,16 @@
-"""Tests for the memcache API."""
-
+from google.appengine.api import memcache
 import pytest
 import time
 
-from google.appengine.api import memcache
+key1 = 'key1'
+data1 = 'data1'
+timeout = 2
+timeout_tolerance = 2
 
-
-@pytest.fixture
-def defaults():
-  memcache.flush_all()
-  return {
-      'client': memcache._CLIENT,
-      'mapping': {
-          'key1', 'data1',
-          'key2', 'data2',
-          'key3', 'data3',
-      },
-      'timeout': 2,
-      'timeout_tolerance': 2,
-      'namespace1': 'foo',
-      'namespace2': 'bar',
-      'default_range': 10,
-      'default_incr_start': 1,
-      'default_decr_start': 1000,
-      'default_delta': 10,
-  }
-
-
-def test_memcache(defaults):
-  assert memcache.get('key1') == None
-  memcache.set('key1', 'data1')
-  assert memcache.get('key1') == 'data1'
-  assert memcache.set('key1', 'data1', defaults['timeout'])
-  time.sleep(defaults['timeout'] + defaults['timeout_tolerance'])
-  assert memcache.get('key1') == None
+def test_memcache():
+  assert memcache.get(key1) == None
+  memcache.set(key1, data1)
+  assert memcache.get(key1) == data1
+  assert memcache.set(key1, data1, timeout)
+  time.sleep(timeout + timeout_tolerance)
+  assert memcache.get(key1) == None

--- a/tests/e2e/tests/search_test.py
+++ b/tests/e2e/tests/search_test.py
@@ -1,7 +1,4 @@
-"""Tests for the search API.
-
-This test module is incomplete but is a starter.
-"""
+"""Tests for the search API."""
 
 import pytest
 import time

--- a/tests/e2e/tests/search_test.py
+++ b/tests/e2e/tests/search_test.py
@@ -1,10 +1,6 @@
-"""Tests for the search API."""
-
+from google.appengine.api import search
 import pytest
 import time
-
-from google.appengine.api import search
-
 
 @pytest.fixture
 def index():

--- a/tests/e2e/tests/search_test.py
+++ b/tests/e2e/tests/search_test.py
@@ -1,0 +1,29 @@
+"""Tests for the search API.
+
+This test module is incomplete but is a starter.
+"""
+
+import pytest
+import time
+
+from google.appengine.api import search
+
+
+@pytest.fixture
+def index():
+  index = search.Index(name='simple-index', namespace='')
+  doc = search.Document(doc_id='test_id', fields=[
+      search.TextField(name='body', value='hello world'),
+  ])
+  index.put(doc)
+  return index
+
+
+def test_basic_search(index):
+  resp = index.search('hello')
+  assert len(resp.results) == 1
+  result = resp.results[0]
+  assert result.doc_id == 'test_id'
+  assert result.language == 'en'
+  assert result.fields[0].value == 'hello world'
+  assert result.fields[0].name == 'body'

--- a/tests/e2e/tests/urlfetch_test.py
+++ b/tests/e2e/tests/urlfetch_test.py
@@ -1,0 +1,16 @@
+"""Tests for the urlfetch API."""
+
+import pytest
+import time
+
+from google.appengine.api import urlfetch
+
+
+@pytest.fixture
+def url():
+  return 'http://www.google.com'
+
+def test_urlfetch(url):
+  resp = urlfetch.fetch(url)
+  assert resp.status_code == 200
+  assert resp.headers['content-length'] == str(len(resp.content))

--- a/tests/e2e/tests/urlfetch_test.py
+++ b/tests/e2e/tests/urlfetch_test.py
@@ -1,16 +1,10 @@
-"""Tests for the urlfetch API."""
-
+from google.appengine.api import urlfetch
 import pytest
 import time
 
-from google.appengine.api import urlfetch
+url = 'http://www.google.com'
 
-
-@pytest.fixture
-def url():
-  return 'http://www.google.com'
-
-def test_urlfetch(url):
+def test_urlfetch():
   resp = urlfetch.fetch(url)
   assert resp.status_code == 200
   assert resp.headers['content-length'] == str(len(resp.content))

--- a/tests/e2e/tests/users_test.py
+++ b/tests/e2e/tests/users_test.py
@@ -1,12 +1,7 @@
-"""E2E test for Users API."""
+from google.appengine.api import users
 import pytest
 
-from google.appengine.api import users
+user = users.get_current_user()
 
-
-@pytest.fixture
-def user():
-  return users.get_current_user()
-
-def test_current_user(user):
+def test_current_user():
   assert user == None

--- a/tests/e2e/tests/users_test.py
+++ b/tests/e2e/tests/users_test.py
@@ -1,0 +1,12 @@
+"""E2E test for Users API."""
+import pytest
+
+from google.appengine.api import users
+
+
+@pytest.fixture
+def user():
+  return users.get_current_user()
+
+def test_current_user(user):
+  assert user == None


### PR DESCRIPTION
Adding a set of basic e2e tests demonstrating that the APIs listed [here](https://cloud.google.com/appengine/docs/flexible/python/migrating-an-existing-app) can at least be accessed.

Note: The logging API does not appear to be supported.

R: @jonparrott 
CC: @andrewsg 