### PR TITLE
Look for mangled name HTTP_X_CLOUD_TRACE_CONTEXT in env

### DIFF
--- a/appengine-vmruntime/vmruntime/cloud_logging.py
+++ b/appengine-vmruntime/vmruntime/cloud_logging.py
@@ -83,7 +83,7 @@ class CloudLoggingHandler(logging.handlers.RotatingFileHandler):
             # formatted "{hexadecimal trace id}/{options}", where the / and
             # the options are themselves optional. We only want the trace ID,
             # so let's drop anything after a "/" if one exists.
-            trace_id = os.getenv('X-Cloud-Trace-Context', '').split('/')[0]
+            trace_id = os.getenv('HTTP_X_CLOUD_TRACE_CONTEXT', '').split('/')[0]
 
         # Now add a traceID key to the payload, if one was found.
         if trace_id:

--- a/appengine-vmruntime/vmruntime/tests/cloud_logging_test.py
+++ b/appengine-vmruntime/vmruntime/tests/cloud_logging_test.py
@@ -74,11 +74,11 @@ class CloudLoggingTestCaseWithTraceIdEnv(CloudLoggingTestCase):
 
     def setUp(self):
         super(CloudLoggingTestCaseWithTraceIdEnv, self).setUp()
-        os.environ['X-Cloud-Trace-Context'] = '{}/12345;o=1'.format(
+        os.environ['HTTP_X_CLOUD_TRACE_CONTEXT'] = '{}/12345;o=1'.format(
             self.EXPECTED_TRACE_ID)
 
     def tearDown(self):
-        os.unsetenv('X-Cloud-Trace-Context')
+        os.unsetenv('HTTP_X_CLOUD_TRACE_CONTEXT')
 
 
 class CloudLoggingTestCaseWithTraceIdEnvNoOptions(CloudLoggingTestCase):
@@ -87,7 +87,7 @@ class CloudLoggingTestCaseWithTraceIdEnvNoOptions(CloudLoggingTestCase):
 
     def setUp(self):
         super(CloudLoggingTestCaseWithTraceIdEnvNoOptions, self).setUp()
-        os.environ['X-Cloud-Trace-Context'] = self.EXPECTED_TRACE_ID
+        os.environ['HTTP_X_CLOUD_TRACE_CONTEXT'] = self.EXPECTED_TRACE_ID
 
     def tearDown(self):
-        os.unsetenv('X-Cloud-Trace-Context')
+        os.unsetenv('HTTP_X_CLOUD_TRACE_CONTEXT')


### PR DESCRIPTION
The Cloud Trace ID is not being added to logs because we're looking for the header name, not the mangled CGI-like environment variable name, in the system environment.

R: @bryanmau1 CC: @JustinBeckwith 