### PR TITLE
Catch KeyError('MODULE_YAML_PATH') when initializing the app

### DIFF
--- a/appengine-vmruntime/vmruntime/tests/wsgi_test.py
+++ b/appengine-vmruntime/vmruntime/tests/wsgi_test.py
@@ -165,6 +165,14 @@ def set_callback(request):
     callback.SetRequestEndCallback(my_callback)
     return wrappers.Response("pass!")
 
+class EnableAppEngineApisTestCase(unittest.TestCase):
+    def test_enable_app_engine_apis_warning(self):
+        from google.appengine.ext.vmruntime import vmconfig
+        with patch.object(wsgi_config, 'get_module_config_filename') as m:
+            m.side_effect = KeyError('MODULE_YAML_PATH')
+            with self.assertRaises(RuntimeError) as a:
+                from vmruntime import wsgi
+            self.assertIn('enable_app_engine_apis: true', a.exception.args[0])
 
 
 class MetaAppTestCase(unittest.TestCase):

--- a/appengine-vmruntime/vmruntime/wsgi.py
+++ b/appengine-vmruntime/vmruntime/wsgi.py
@@ -53,8 +53,6 @@ except KeyError as e:
         '\'enable_app_engine_apis: true\' under beta_settings in app.yaml.')
   else:
     raise
-except:
-  raise
 
 env_config = vmconfig.BuildVmAppengineEnvConfig()
 

--- a/appengine-vmruntime/vmruntime/wsgi.py
+++ b/appengine-vmruntime/vmruntime/wsgi.py
@@ -43,8 +43,19 @@ except IOError:
 root_logger.setLevel(logging.INFO)
 
 # Fetch application configuration via the config file.
-appinfo = wsgi_config.get_module_config(wsgi_config.get_module_config_filename(
-))
+try:
+    appinfo = wsgi_config.get_module_config(
+        wsgi_config.get_module_config_filename())
+except KeyError as e:
+  if e.args[0] == 'MODULE_YAML_PATH':
+    raise RuntimeError('An error occured when initializing the runtime. If you '
+        'are using \'env: flex\', this may be because you forgot to set '
+        '\'enable_app_engine_apis: true\' under beta_settings in app.yaml.')
+  else:
+    raise
+except:
+  raise
+
 env_config = vmconfig.BuildVmAppengineEnvConfig()
 
 # Ensure API requests include a valid ticket by default.


### PR DESCRIPTION
Catch KeyError('MODULE_YAML_PATH') when initializing the app, and throw a more helpful error.