### PR TITLE
Remove extraneous symlink at /home/vmagent/app/app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ COPY resources/requirements.txt /opt/requirements.txt
 RUN pip install --upgrade -r /opt/requirements.txt
 
 # Setup the application directory
-RUN ln -s /home/vmagent/app /app
 WORKDIR /app
 
 # Add the default gunicorn configuration file to the app directory. This


### PR DESCRIPTION
Currently, /home/vmagent/app/app is a circular symlink to /home/vmagent/app

Caused by running 'ln -s /home/vmagent/app /app' twice, once in the
python-runtime Dockerfile, and a second time in this Dockerfile.